### PR TITLE
記事詳細画面のレイアウト変更

### DIFF
--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -13,7 +13,7 @@ import getBlogIndex from '../../lib/notion/getBlogIndex'
 import getNotionUsers from '../../lib/notion/getNotionUsers'
 import { getBlogLink, getDateStr } from '../../lib/blog-helpers'
 
-import { Heading } from 'grommet'
+import { Box, Heading, Text } from 'grommet'
 
 // Get the data for each blog post
 export async function getStaticProps({ params: { slug }, preview }) {
@@ -153,8 +153,25 @@ const RenderPost = ({ post, redirect, preview }) => {
           </div>
         </div>
       )}
-      <div className={blogStyles.post}>
-        <Heading color="neutral-3" size="large" margin="auto">
+      {/*ブログ記事表示部*/}
+      <Box
+        as="div"
+        className={blogStyles.post}
+        margin={{
+          top: 'none',
+          bottom: 'none',
+          left: 'medium',
+          right: 'medium',
+        }}
+        pad={{
+          top: 'none',
+          bottom: 'none',
+          left: 'medium',
+          right: 'medium',
+        }}
+        gap="small"
+      >
+        <Heading color="neutral-3" size="medium" margin="small">
           {' '}
           {post.Page || ''}
         </Heading>
@@ -162,7 +179,9 @@ const RenderPost = ({ post, redirect, preview }) => {
           <div className="authors">By: {post.Authors.join(' ')}</div>
         )}
         {post.Date && (
-          <div className="posted">Posted: {getDateStr(post.Date)}</div>
+          <Text color="dark-3" margin="small" size="medium">
+            Posted: {getDateStr(post.Date)}
+          </Text>
         )}
 
         <hr />
@@ -525,7 +544,7 @@ const RenderPost = ({ post, redirect, preview }) => {
           }
           return toRender
         })}
-      </div>
+      </Box>
     </>
   )
 }

--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -130,7 +130,8 @@
 }
 
 .post :global(hr) {
-  margin-bottom: 2em;
+  /*margin-bottom: 2em;*/
+  width: 100%;
 }
 
 .post :global(a + p) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -254,6 +254,7 @@ figure {
 a {
   color: #777777;
   text-decoration: none;
+  word-break: break-all;
 }
 a:hover {
   color: #3291ff;


### PR DESCRIPTION
主にコンテンツ表示幅の拡張、h1タグや「posted」テキストのスタイル変更を実施した。